### PR TITLE
Basic release support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,36 @@ and then browse to http://localhost:8000. If you edit files in the
 `docs` directory, your changes should be reflected in the browser.
 
 
+### Cutting a release
+
+Here's how to cut a new release. First off, run the release command
+from the master branch within your local repository. At the moment,
+the command implementation blindly assumes the current directory is
+the repository's root directory, so make sure that is the case as in
+the sequences of commands below. The release command takes three
+numbers as input: major, minor and patch numbers of the version you
+want to release. It then
+
+1. Updates the first line of `docs/index.md` with the date of
+    the latest commit in the `docs` dir.
+2. Commits the change and tags with the specified version.
+3. Pushes the commit and the tag to remote.
+
+For example, the commands below would release version `2.1.4` and
+tag the commit with `v2.1.4`.
+
+```bash
+$ cd nix
+$ nix shell
+$ cd ..
+$ oc release 2 1 4
+```
+
+Next, [build the static site tarball][docs-site] from the current
+git commit, create a GitHub release for the version just tagged
+(e.g. `v2.1.4`) and upload the tarball to the GitHub release.
+
+
 ### Publishing the site
 
 We build a static Web site and package it in a tarball. You should

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ How to get the tarball containing the static documentation site?
 Either download it from a [GitHub Release][releases] or [build it
 yourself][docs-site] with Nix. Even better, if you have a Nix-based
 Web server setup, you could just import the `docs` directory of one
-of our `docs-site` Nix packages, e.g. `docs-site.v1.0.0` for the
+of our `docs-site` Nix packages, e.g. `docs-site.v1_0_0` for the
 `v1.0.0` release or `docs-site.git` for the current content of the
 master branch.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,40 @@ $ cd nix
 $ nix shell
 ```
 
+Once in the Nix shell, any script with a shebang of `#!/bin/sh` gets
+executed by the Bash bundled in our Nix shell. For example, save the
+script below as `nix/test.sh` and make it executable
+
+```bash
+#!/bin/sh
+
+sh --version
+
+echo ----------------
+which sh
+readlink $(which sh)
+```
+
+Running the script inside the Nix shell yields
+
+```
+GNU bash, version 5.2.26(1)-release (aarch64-apple-darwin23.5.0)
+...
+----------------
+/nix/store/8dhzx8i8xp8cl3m33xailx1d48g54m58-dev-shell/bin/sh
+/nix/store/fyjay93q3dq2hx3dhx7zhr8kyjnkh9m8-bash-5.2p26/bin/sh
+```
+
+whereas running it *outside* of the Nix shell on my MacOS M1 with
+Bash set as a default shell
+
+```
+GNU bash, version 3.2.57(1)-release (arm64-apple-darwin23)
+...
+----------------
+/bin/sh
+```
+
 
 ### Editing content
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Next, [build the static site tarball][docs-site] from the current
 git commit, create a GitHub release for the version just tagged
 (e.g. `v2.1.4`) and upload the tarball to the GitHub release.
 
+Finally, update the `docs-site` Nix package to include this release.
+
 
 ### Publishing the site
 

--- a/README.md
+++ b/README.md
@@ -78,14 +78,24 @@ and then browse to http://localhost:8000. If you edit files in the
 `docs` directory, your changes should be reflected in the browser.
 
 
-### Deploying the site
+### Publishing the site
 
-To go live with your changes, first build the Nix package
+We build a static Web site and package it in a tarball. You should
+be able to just extract the tarball in a suitable directory on a
+Web server and serve the plain files in the extracted directory.
+That's basically what we do to publish the documentation to our
+Nginx machine serving `docs.orchestracities.com`.
 
-```bash
-$ cd nix
-$ nix build .#docs-site
-```
+How to get the tarball containing the static documentation site?
+Either download it from a [GitHub Release][releases] or [build it
+yourself][docs-site] with Nix. Even better, if you have a Nix-based
+Web server setup, you could just import the `docs` directory of one
+of our `docs-site` Nix packages, e.g. `docs-site.v1.0.0` for the
+`v1.0.0` release or `docs-site.git` for the current content of the
+master branch.
 
-then upload and extract `result/docs.tgz` to our Nginx machine
-serving `docs.orchestracities.com`.
+
+
+
+[docs-site]: ./nix/pkgs/docs-site/docs.md
+[releases]: https://github.com/orchestracities/documentation/releases

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,19 @@
+Orchestra Cities Documentation
+------------------------------
+> Release notes
+
+
+## Version 1.0.1
+
+**Release Date: 08 August 2024**
+
+Build system migration to Nix. No changes to the actual documentation
+content from version `1.0.0`.
+
+
+## Version 1.0.0
+
+**Release Date: 28 July 2020**
+
+Initial platform documentation covering configuration and operation
+of core services.

--- a/nix/pkgs/cli-tools/default.nix
+++ b/nix/pkgs/cli-tools/default.nix
@@ -1,1 +1,1 @@
-{ pkgs }: pkgs.callPackage ./pkg.nix {}
+{ pkgs, scripts }: pkgs.callPackage ./pkg.nix { inherit scripts; }

--- a/nix/pkgs/cli-tools/pkg.nix
+++ b/nix/pkgs/cli-tools/pkg.nix
@@ -1,7 +1,7 @@
 #
 # See `docs.md` for package documentation.
 #
-{ pkgs }:
+{ pkgs, scripts }:
 rec {
 
   tools = with pkgs; [
@@ -11,6 +11,7 @@ rec {
     git
     mkdocs
     python3
+    scripts
   ];
 
   # Make a shell env with all the given programs.

--- a/nix/pkgs/docs-site/docs.md
+++ b/nix/pkgs/docs-site/docs.md
@@ -7,6 +7,43 @@ in the `docs` directory. The static site files go in the `docs` output
 directory and also get packaged in a `docs.tgz` tarball for extra
 convenience---`docs` is also the root directory in the tarball.
 
+We keep a few package versions out of convenience. The `docs-site`
+Nix package is just a dummy package to group the actual package
+versions. There's a `git` package which we build either from the
+local source in you git repo if you build locally
+
+```bash
+$ cd nix
+$ nix build .#docs-site.git
+$ ls result
+docs/     docs.tgz
+```
+
+or the current source in the master branch if you build remotely
+
+```bash
+$ nix build github:orchestracities/documentation?dir=nix#docs-site.git
+$ ls result
+docs/     docs.tgz
+```
+
+We also keep a few packages for some of the releases. These packages
+always fetch the source as it was at a given git revision, regardless
+of whether you build from your repo clone
+
+```bash
+$ cd nix
+$ nix build .#docs-site.v1_0_1
+$ ls result
+docs/     docs.tgz
+```
+
+or remotely
+
+```bash
+$ nix build github:orchestracities/documentation?dir=nix#docs-site.v1.0.1
+```
+
 Have a look at [pkg.nix][pkg] if you're interested in the Nix package
 details.
 

--- a/nix/pkgs/docs-site/mk-pkg.nix
+++ b/nix/pkgs/docs-site/mk-pkg.nix
@@ -1,0 +1,40 @@
+#
+# Make a docs site package either from a GitHub release or from
+# local source.
+#
+{
+  stdenv, fetchFromGitHub, mkdocs,
+
+  # Pass in release info, e.g.
+  # { version = 'v1.0.0'; rev = 'v1.0.0'; sha256 = 'wada-wada'; }
+  # If null, then set version to "git" and use local source.
+  release ? null
+}:
+let
+  version = if release == null
+            then "git"
+            else release.version;
+  src = if release == null
+        then ../../../.
+        else fetchFromGitHub {
+          owner = "orchestracities";
+          repo = "documentation";
+          rev = release.rev;
+          sha256 = release.sha256;
+        };
+in stdenv.mkDerivation {
+  pname = "docs-site";
+  inherit version src;
+
+  buildInputs = [ mkdocs ];
+
+  buildPhase = ''
+    mkdocs build
+  '';
+
+  installPhase = ''
+    mkdir -p $out/docs
+    cp -r site/* $out/docs
+    tar czf $out/docs.tgz -C $out docs
+  '';
+}

--- a/nix/pkgs/docs-site/pkg.nix
+++ b/nix/pkgs/docs-site/pkg.nix
@@ -1,24 +1,32 @@
 #
 # See `docs.md` for package documentation.
 #
-{
-  stdenv, mkdocs
-}:
-stdenv.mkDerivation {
-  pname = "docs-site";
-  version = "2020-07-26";
+{ pkgs }:
+derivation {
+  system = pkgs.system;
+  name = "docs-site-pkg-group";                                # (1)
+  builder = "";
 
-  src = ../../../.;  # TODO: replace w/ GitHub when we have a release.
-
-  buildInputs = [ mkdocs ];
-
-  buildPhase = ''
-    mkdocs build
-  '';
-
-  installPhase = ''
-    mkdir -p $out/docs
-    cp -r site/* $out/docs
-    tar czf $out/docs.tgz -C $out docs
-  '';
+  git = pkgs.callPackage ./mk-pkg.nix {};
+  v1_0_1 = pkgs.callPackage ./mk-pkg.nix {
+    release = {
+      version = "v1.0.1";
+      rev = "6b534b1065f536a66921d29e8234140f9f6a7a8f";
+      sha256 = "sha256-wJPp856/LtUP70nzftVLWU1JomJI7gMXg8gBn0jIhFw=";
+    };
+  };
+  v1_0_0 = pkgs.callPackage ./mk-pkg.nix {
+    release = {
+      version = "v1.0.0";
+      rev = "0db46d6e450efaf0025abcd544fec054b122f6e7";
+      sha256 = "sha256-Ekgx6zHJWVhkKb9/gHMzx36GGgN0GF7ReXfX/HQjIiA=";
+    };
+  };
 }
+# NOTE
+# ----
+# 1. Package scope. How to create one that works with Flakes?
+# I've tried doing it the "proper" way, with a package scope, but
+# that didn't work---see `scope-wip` dir. So I'm trying my luck w/
+# an empty derivation which seems to work fine so far.
+#

--- a/nix/pkgs/docs-site/scope-wip/README.md
+++ b/nix/pkgs/docs-site/scope-wip/README.md
@@ -1,0 +1,17 @@
+Nix Package Scope
+-----------------
+> or how the hell are you supposed to do it
+
+I've tried creating a "proper" Nix package scope for `docs-site`.
+See the two files in this dir. I didn't change `mkSysOutput.nix`
+so the top-level package is the package scope:
+
+```nix
+  docs-site = import ./docs-site { pkgs = sysPkgs; };
+```
+
+But Nix complained loudly with:
+
+```
+error: expected a derivation
+```

--- a/nix/pkgs/docs-site/scope-wip/default.nix
+++ b/nix/pkgs/docs-site/scope-wip/default.nix
@@ -1,0 +1,11 @@
+{ pkgs }:
+pkgs.lib.attrsets.recurseIntoAttrs (                                # (1)
+  pkgs.callPackage ./pkg.nix {}
+)
+# NOTE
+# ----
+# 1. Package scope. How to create one? Not mentioned in the official
+# Nix docs it seems, but see
+# - https://discourse.nixos.org/t/namespacing-scoping-a-group-of-packages/13782/4
+# - https://github.com/NixOS/nixpkgs/commit/632c4f2c9ba1f88cd5662da7bedf2ca5f0cda4a9
+#

--- a/nix/pkgs/docs-site/scope-wip/pkg.nix
+++ b/nix/pkgs/docs-site/scope-wip/pkg.nix
@@ -1,0 +1,30 @@
+#
+# See `docs.md` for package documentation.
+#
+{
+  pkgs, lib
+}:
+lib.makeScope pkgs.newScope (self: with self; {                # (1)
+  git = callPackage ./mk-pkg.nix {};
+  v1_0_1 = callPackage ./mk-pkg.nix {
+    release = {
+      version = "v1.0.1";
+      rev = "6b534b1065f536a66921d29e8234140f9f6a7a8f";
+      sha256 = lib.fakeSha256;
+    };
+  };
+  v1_0_0 = callPackage ./mk-pkg.nix {
+    release = {
+      version = "v1.0.0";
+      rev = "0db46d6e450efaf0025abcd544fec054b122f6e7";
+      sha256 = lib.fakeSha256;
+    };
+  };
+})
+# NOTE
+# ----
+# 1. Package scope. How to create one? Not mentioned in the official
+# Nix docs it seems, but see
+# - https://discourse.nixos.org/t/namespacing-scoping-a-group-of-packages/13782/4
+# - https://github.com/NixOS/nixpkgs/commit/632c4f2c9ba1f88cd5662da7bedf2ca5f0cda4a9
+#

--- a/nix/pkgs/mkSysOutput.nix
+++ b/nix/pkgs/mkSysOutput.nix
@@ -10,7 +10,8 @@
 }:
 let
   docs-site = import ./docs-site { pkgs = sysPkgs; };
-  tools = import ./cli-tools { pkgs = sysPkgs; };
+  scripts = import ./scripts { pkgs = sysPkgs; };
+  tools = import ./cli-tools { pkgs = sysPkgs; inherit scripts; };
 in rec {
   packages.${system} = {
     default = tools.dev-shell;

--- a/nix/pkgs/scripts/commands.sh
+++ b/nix/pkgs/scripts/commands.sh
@@ -1,0 +1,85 @@
+#
+# Grab the date of the latest commit in a given remote git repo dir.
+#
+# Params:
+# - $1: repo URL, e.g. https://github.com/orchestractities/documentation.
+# - $2: git tag to checkout, e.g. 'v1.0.0'.
+# - $3: target dir from where to get the latest commit date, e.g. docs.
+#
+# Return:
+# - The committer date of the most recent commit in $3. E.g.
+#   'Thu Aug 8 15:10:36 2024 +0200'
+#
+function commit_date_from_remote() {
+    local repo_url=$1
+    local tag=$2
+    local commit_dir=$3
+    local tmp_dir='__tmp__'
+
+    pushd .
+    mkdir "${tmp_dir}" && cd "${tmp_dir}"
+
+    git clone --depth=1 --branch "${tag}" "${repo_url}" .
+    commit_date=$(git log -n 1 --pretty=format:%cd "${commit_dir}")
+
+    popd
+    rm -rf "${tmp_dir}"
+
+    echo ${commit_date}
+}
+
+#
+# Grab the date of the latest commit in a given dir within the local
+# git repo this command runs from.
+#
+# Params:
+# - $1: target dir from where to get the latest commit date, e.g. docs.
+#
+# Return:
+# - The committer date of the most recent commit in $1. E.g.
+#   'Thu Aug 8 15:10:36 2024 +0200'
+#
+function commit_date() {
+    local commit_dir=$1
+    commit_date=$(git log -n 1 --pretty=format:%cd "${commit_dir}")
+    echo ${commit_date}
+}
+
+#
+# Cut a release.
+# IMPORTANT: You must run this command from the repo root dir!
+#
+# This command does the following:
+# 1. Update the first line of `docs/index.md` with the date of
+#    the latest commit in the `docs` dir.
+# 2. Commit the change and tag with the specified version.
+# 3. Push the commit and the tag to remote.
+#
+# Params
+# - $1: major version number, e.g. 1.
+# - $2: minor version number, e.g. 0.
+# - $1: patch version number, e.g. 1.
+#
+function release() {
+    local major=$1
+    local minor=$2
+    local patch=$3
+
+    local version="v${major}.${minor}.${patch}"
+
+    local docs_dir='docs'
+    local latest_doc_commit=$(commit_date "${docs_dir}")
+    sed -i -e "1s/.*/$latest_doc_commit/" "${docs_dir}/index.md"
+
+    # git add .
+    echo git commit -m "release ${version}"
+    echo git tag "${version}"
+    # git push --tags
+}
+
+#
+# Make each function defined so far callable from Bash as e.g.
+# `bash ./commands.sh release 1 0 2` or `./commands.sh release 1 0 2`
+# if `commands.sh` has the exec perm set.
+#
+$*

--- a/nix/pkgs/scripts/commands.sh
+++ b/nix/pkgs/scripts/commands.sh
@@ -73,10 +73,10 @@ function release() {
     sed -i -e "1s/.*/$docs_date/" "${docs_dir}/index.md"
     rm "${docs_dir}/index.md-e"
 
-    # git add .
-    echo git commit -m "release ${version}"
-    echo git tag "${version}"
-    # git push --tags
+    git add .
+    git commit -m "release ${version}"
+    git tag "${version}"
+    git push --tags
 }
 
 #

--- a/nix/pkgs/scripts/commands.sh
+++ b/nix/pkgs/scripts/commands.sh
@@ -69,7 +69,9 @@ function release() {
 
     local docs_dir='docs'
     local latest_doc_commit=$(commit_date "${docs_dir}")
-    sed -i -e "1s/.*/$latest_doc_commit/" "${docs_dir}/index.md"
+    local docs_date="*Latest Update: ${latest_doc_commit}*"
+    sed -i -e "1s/.*/$docs_date/" "${docs_dir}/index.md"
+    rm "${docs_dir}/index.md-e"
 
     # git add .
     echo git commit -m "release ${version}"

--- a/nix/pkgs/scripts/default.nix
+++ b/nix/pkgs/scripts/default.nix
@@ -1,0 +1,1 @@
+{ pkgs }: pkgs.callPackage ./pkg.nix {}

--- a/nix/pkgs/scripts/docs.md
+++ b/nix/pkgs/scripts/docs.md
@@ -1,3 +1,14 @@
 Scripts
 -------
 > Nix package docs.
+
+This package makes some Bash scripts available as subcommands of
+a main `oc` command. These subcommands are functions declared in
+[commands.sh][commands] which [pkg.nix][pkg] bundles in a Bash
+script taking care of including all the dependencies.
+
+
+
+
+[commands]: ./commands.sh
+[pkg]: ./pkg.nix

--- a/nix/pkgs/scripts/docs.md
+++ b/nix/pkgs/scripts/docs.md
@@ -1,0 +1,3 @@
+Scripts
+-------
+> Nix package docs.

--- a/nix/pkgs/scripts/pkg.nix
+++ b/nix/pkgs/scripts/pkg.nix
@@ -1,0 +1,26 @@
+#
+# See `docs.md` for package documentation.
+#
+{
+  stdenv, lib, makeWrapper,
+  bash, coreutils, git
+}:
+let
+  inherit (lib) makeBinPath;
+in stdenv.mkDerivation rec {
+  pname = "scripts";
+  version = "1.0.0";
+
+  src = ./.;
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [
+    bash coreutils git
+  ];
+
+  installPhase = ''
+    install -Dm755 commands.sh $out/bin/oc
+
+    wrapProgram $out/bin/oc --prefix PATH : '${makeBinPath buildInputs}'
+  '';
+}

--- a/update-release-date.sh
+++ b/update-release-date.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-LATEST_UPDATE='*Latest Update: '$(date '+%Y-%m-%d %H:%M:%S')'*'
-sed -i.bak "1s/.*/${LATEST_UPDATE}/" docs/index.md && rm docs/index.md.bak
-echo ${LATEST_UPDATE}


### PR DESCRIPTION
This PR implements basic support for releasing the static doc site tarball.

- Nix packages to build the tarball both locally and remotely. There's a package for each version we support as well as one build from the content in the master branch at the time of running the Nix build.
- Basic scripts to create a release.
- Basic release notes.